### PR TITLE
Configured the MultipartFile upload and request size limit.

### DIFF
--- a/Java/src/main/java/ej2/webservices/RestServiceCorsApplication.java
+++ b/Java/src/main/java/ej2/webservices/RestServiceCorsApplication.java
@@ -1,12 +1,16 @@
 package ej2.webservices;
 import java.util.Collections;
 
+import javax.servlet.MultipartConfigElement;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.util.unit.DataSize;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.web.servlet.MultipartConfigFactory;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 // Refer the licensing package
 import com.syncfusion.licensing.*;
@@ -26,6 +30,14 @@ public class RestServiceCorsApplication extends SpringBootServletInitializer {
 		SpringApplication app = new SpringApplication(RestServiceCorsApplication.class);
 		app.setDefaultProperties(Collections.singletonMap("server.port", "9090"));
 		app.run(args);
+	}
+	
+	@Bean
+	public MultipartConfigElement multipartConfigElement() {
+	    MultipartConfigFactory factory = new MultipartConfigFactory();
+	    factory.setMaxFileSize(DataSize.ofBytes(1073741824));
+	    factory.setMaxRequestSize(DataSize.ofBytes(1073741824));
+	    return factory.createMultipartConfig();
 	}
 
 	// @Bean

--- a/Java/src/main/java/ej2/webservices/RestServiceCorsApplication.java
+++ b/Java/src/main/java/ej2/webservices/RestServiceCorsApplication.java
@@ -35,7 +35,9 @@ public class RestServiceCorsApplication extends SpringBootServletInitializer {
 	@Bean
 	public MultipartConfigElement multipartConfigElement() {
 	    MultipartConfigFactory factory = new MultipartConfigFactory();
+		// Increased the max file size upto 1 GB to resolve the issue of uploading large files.
 	    factory.setMaxFileSize(DataSize.ofBytes(1073741824));
+		// Increased the max request size upto 1 GB to resolve the issue of uploading large files.
 	    factory.setMaxRequestSize(DataSize.ofBytes(1073741824));
 	    return factory.createMultipartConfig();
 	}


### PR DESCRIPTION
We are facing an issue with `FileSizeLimitExceededException` when attempting to upload a file larger than 1MB in our Java Spring Boot application. We have addressed this problem by increasing the size limits for both file uploads and requests in the Spring Boot Java application.